### PR TITLE
Add --quick_release Option for Improved VRAM Management in ZipLoRA Saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ accelerate launch train_dreambooth_ziplora_sdxl.py \
 
 ```
 
+* If you're facing VRAM limitations during training, use the `--quick_release` flag to help free up VRAM.
+
 ### 3. Inference
 
 ```python

--- a/train_dreambooth_ziplora_sdxl.py
+++ b/train_dreambooth_ziplora_sdxl.py
@@ -658,6 +658,11 @@ def parse_args(input_args=None):
         action="store_true",
         help="Whether or not to use xformers.",
     )
+    parser.add_argument(
+        "--quick_release",
+        action="store_true",
+        help="Releases VRAM immediately after processing each layer, conserving it."
+    )
 
     if input_args is not None:
         args = parser.parse_args(input_args)
@@ -1697,7 +1702,7 @@ def main(args):
     if accelerator.is_main_process:
         unet = accelerator.unwrap_model(unet)
         unet = unet.to(torch.float32)
-        unet_lora_layers = unet_ziplora_state_dict(unet)
+        unet_lora_layers = unet_ziplora_state_dict(unet, args.quick_release)
 
         if args.train_text_encoder:
             text_encoder_one = accelerator.unwrap_model(text_encoder_one)

--- a/ziplora_pytorch/utils.py
+++ b/ziplora_pytorch/utils.py
@@ -70,7 +70,9 @@ def initialize_ziplora_layer(state_dict, state_dict_2, part, **model_kwargs):
     return ziplora_layer
 
 
-def unet_ziplora_state_dict(unet: UNet2DConditionModel) -> Dict[str, torch.Tensor]:
+def unet_ziplora_state_dict(
+    unet: UNet2DConditionModel, quick_release: bool = False
+) -> Dict[str, torch.Tensor]:
     r"""
     Returns:
         A state dict containing just the LoRA parameters.
@@ -84,6 +86,9 @@ def unet_ziplora_state_dict(unet: UNet2DConditionModel) -> Dict[str, torch.Tenso
                 assert hasattr(lora_layer, "get_ziplora_weight"), lora_layer
                 weight = lora_layer.get_ziplora_weight()
                 lora_state_dict[f"unet.{name}.lora.weight"] = weight
+
+            if quick_release:
+                module.cpu()
     return lora_state_dict
 
 

--- a/ziplora_pytorch/utils.py
+++ b/ziplora_pytorch/utils.py
@@ -87,8 +87,8 @@ def unet_ziplora_state_dict(
                 weight = lora_layer.get_ziplora_weight()
                 lora_state_dict[f"unet.{name}.lora.weight"] = weight
 
-            if quick_release:
-                module.cpu()
+                if quick_release:
+                    lora_layer.cpu()
     return lora_state_dict
 
 


### PR DESCRIPTION
There's unnecessary VRAM usage in the saving phase of ZipLoRA training.
This commit makes training fit within 24GB VRAM (like on a 4090), allowing one to train without needing the xformers option.